### PR TITLE
Add static credential rotation capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,15 @@ $ vault write database/config/oracle plugin_name \
     username='vaultadmin' \
     password='reallysecurepassword'
 
-# Rotate the admin password immediately. Note that the new password will never be made available through Vault,
-# so you should create a vault-specific database admin user for this
+# You should consider rotating the admin password. Note that if you do, the new password will never be made available
+# through Vault, so you should create a vault-specific database admin user for this.
 $ vault write -force database/rotate-root/oracle
 ```
 
 If running the plugin on MacOS you may run into an issue where the OS prevents the Oracle libraries from being executed.
 See [How to open an app that hasn't been notarized or is from an unidentified developer](https://support.apple.com/en-us/HT202491)
 on Apple's support website to be able to run this.
+
+## Usage Notes
+The [rotation statements](https://www.vaultproject.io/api/secret/databases/index.html#rotation_statements) are optional
+and will default to `ALTER USER "{{username}}" IDENTIFIED BY "{{password}}"`

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ on Apple's support website to be able to run this.
 
 ### Case Sensitivity
 
-It is important that you do NOT specify double quotes around the username in any of the creation or rotation statements.
+It is important that you do NOT specify double quotes around the username in any of the SQL statements.
 Otherwise Oracle may create/look up a user with the incorrect name (`foo_bar` instead of `FOO_BAR`).
 
 ### Default statements

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Sample commands for registering and starting to use the plugin:
 $ shasum -a 256 vault-plugin-database-oracle > /tmp/oracle-plugin.sha256
 
 $ vault write sys/plugins/catalog/database/vault-plugin-database-oracle \
-    sha_256=$(cat /tmp/oracle-plugin.sha256) \
+    sha256=$(cat /tmp/oracle-plugin.sha256) \
     command="vault-plugin-database-oracle"
 
 $ vault secrets enable database

--- a/README.md
+++ b/README.md
@@ -10,9 +10,19 @@ For linux/amd64, pre-built binaries can be found at [the releases page](https://
 
 For other platforms, there are not currently pre-built binaries available.
 
-Before building, you will need to download the Oracle Instant Client library, which is available from [Oracle](http://www.oracle.com/technetwork/database/features/instant-client/index-097480.html). Download the SDK package to get the headers and download the Basic package to get the libraries for your platform. The libraries and headers should be installed at one of the standard locations for your platform (e.g. on macOS, `/usr/local/include`&`/usr/local/lib` or `~/include`&`~/lib`).
+Before building, you will need to download the Oracle Instant Client library, which is available from
+[Oracle](http://www.oracle.com/technetwork/database/features/instant-client/index-097480.html). Download the SDK package to get the headers and
+download the Basic package to get the libraries for your platform. Inside the SDK package's subfolder: `instantclient_<version>/sdk/include/` are a
+number of header files. Similarly, inside the Basic package's subfolder: `instantclient_<version>/` are a number of library files. These will need to
+be placed into the standard locations for your platform.
 
-Next, create a [`pkg-config`](https://www.freedesktop.org/wiki/Software/pkg-config/) file to point to the library. Create the file `oci8.pc` on your `PKG_CONFIG_PATH`.
+For instance, if you are using MacOS, place the header files from the SDK package into either `/usr/local/include/` or `~/include/`.
+Similarly, place the library files from the Basic package into either `/usr/local/lib/` or `~/lib/`
+
+Next, ensure that you have [`pkg-config`](https://www.freedesktop.org/wiki/Software/pkg-config/) installed on your system. For MacOS, you can install
+it using `brew install pkg-config`.
+
+Create a `pkg-config` file to point to the library. Create the file `oci8.pc` on your `PKG_CONFIG_PATH`.
 
 An example `oci8.pc` for macOS is:
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Then, `git clone` this repository into your `$GOPATH` and `go build -o vault-plu
 
 ## Installation
 
+**See [Case Sensitivity](#case-sensitivity) for important information about custom creation & rotation statements.**
+
 The Vault plugin system is documented on the [Vault documentation site](https://www.vaultproject.io/docs/internals/plugins.html).
 
 You will need to define a plugin directory using the `plugin_directory` configuration directive, then place the
@@ -81,6 +83,14 @@ If running the plugin on MacOS you may run into an issue where the OS prevents t
 See [How to open an app that hasn't been notarized or is from an unidentified developer](https://support.apple.com/en-us/HT202491)
 on Apple's support website to be able to run this.
 
-## Usage Notes
+## Usage
+
+### Case Sensitivity
+
+It is important that you do NOT specify double quotes around the username in any of the creation or rotation statements.
+Otherwise Oracle may create/look up a user with the incorrect name (`foo_bar` instead of `FOO_BAR`).
+
+### Default statements
+
 The [rotation statements](https://www.vaultproject.io/api/secret/databases/index.html#rotation_statements) are optional
-and will default to `ALTER USER "{{username}}" IDENTIFIED BY "{{password}}"`
+and will default to `ALTER USER {{username}} IDENTIFIED BY "{{password}}"`

--- a/oracle.go
+++ b/oracle.go
@@ -143,7 +143,9 @@ func (o *Oracle) CreateUser(ctx context.Context, statements dbplugin.Statements,
 			}
 
 			m := map[string]string{
-				"name":       username,
+				// Uppercase the username because Oracle does this already for us. This way our code is consistently
+				// uppercased in case this behavior changes or is different between Oracle versions.
+				"name":       strings.ToUpper(username),
 				"password":   password,
 				"expiration": expirationStr,
 			}
@@ -207,7 +209,8 @@ func (o *Oracle) RevokeUser(ctx context.Context, statements dbplugin.Statements,
 			}
 
 			m := map[string]string{
-				"name": username,
+				// Uppercased for consistency with Oracle and other CRUD functions
+				"name": strings.ToUpper(username),
 			}
 
 			if err := dbtxn.ExecuteTxQuery(ctx, tx, m, query); err != nil {
@@ -258,7 +261,8 @@ func (o *Oracle) RotateRootCredentials(ctx context.Context, statements []string)
 			}
 
 			m := map[string]string{
-				"username": o.Username,
+				// Uppercased for consistency with Oracle and other CRUD functions
+				"username": strings.ToUpper(o.Username),
 				"password": password,
 			}
 
@@ -293,6 +297,7 @@ func (o *Oracle) SetCredentials(ctx context.Context, statements dbplugin.Stateme
 	}
 
 	variables := map[string]string{
+		// Uppercase because Oracle uppercases the username on creation but not when logging in
 		"username": strings.ToUpper(username),
 		"password": password,
 	}

--- a/oracle.go
+++ b/oracle.go
@@ -122,9 +122,8 @@ func (o *Oracle) CreateUser(ctx context.Context, statements dbplugin.Statements,
 		return "", "", err
 
 	}
-	defer func() {
-		tx.Rollback()
-	}()
+	// Effectively a no-op if the transaction commits successfully
+	defer tx.Rollback()
 
 	// Execute each query
 	for _, stmt := range statements.Creation {
@@ -175,9 +174,8 @@ func (o *Oracle) RevokeUser(ctx context.Context, statements dbplugin.Statements,
 	if err != nil {
 		return err
 	}
-	defer func() {
-		tx.Rollback()
-	}()
+	// Effectively a no-op if the transaction commits successfully
+	defer tx.Rollback()
 
 	if err := o.disconnectSession(db, username); err != nil {
 		return err
@@ -233,9 +231,8 @@ func (o *Oracle) RotateRootCredentials(ctx context.Context, statements []string)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		tx.Rollback()
-	}()
+	// Effectively a no-op if the transaction commits successfully
+	defer tx.Rollback()
 
 	password, err := o.GeneratePassword()
 	if err != nil {
@@ -307,6 +304,7 @@ func (o *Oracle) SetCredentials(ctx context.Context, statements dbplugin.Stateme
 	if err != nil {
 		return "", "", fmt.Errorf("unable to create database transaction: %w", err)
 	}
+	// Effectively a no-op if the transaction commits successfully
 	defer tx.Rollback()
 
 	for _, rawQuery := range queries {

--- a/oracle.go
+++ b/oracle.go
@@ -280,6 +280,20 @@ func (o *Oracle) RotateRootCredentials(ctx context.Context, statements []string)
 	return o.RawConfig, nil
 }
 
+func splitQueries(rawQueries []string) (queries []string) {
+	for _, rawQ := range rawQueries {
+		split := strutil.ParseArbitraryStringSlice(rawQ, ";")
+		for _, newQ := range split {
+			newQ = strings.TrimSpace(newQ)
+			if newQ == "" {
+				continue
+			}
+			queries = append(queries, newQ)
+		}
+	}
+	return queries
+}
+
 func (o *Oracle) disconnectSession(db *sql.DB, username string) error {
 	disconnectStmt, err := db.Prepare(strings.Replace(sessionQuerySQL, "{{name}}", username, -1))
 	if err != nil {

--- a/oracle_test.go
+++ b/oracle_test.go
@@ -30,7 +30,7 @@ func prepareOracleTestContainer(t *testing.T) (cleanup func(), connString string
 		t.Fatalf("Failed to connect to docker: %s", err)
 	}
 
-	resource, err := pool.Run("wnameless/oracle-xe-11g", "latest", []string{})
+	resource, err := pool.Run("wnameless/oracle-xe-11g-r2", "latest", []string{})
 	if err != nil {
 		t.Fatalf("Could not start local Oracle docker container: %s", err)
 	}

--- a/oracle_test.go
+++ b/oracle_test.go
@@ -20,9 +20,9 @@ const (
 	defaultPassword = "oracle"
 )
 
-func prepareOracleTestContainer(t *testing.T) (cleanup func(), connString string) {
+func prepareOracleTestContainer(t *testing.T) (connString string, cleanup func()) {
 	if os.Getenv("ORACLE_DSN") != "" {
-		return func() {}, os.Getenv("ORACLE_DSN")
+		return os.Getenv("ORACLE_DSN"), func() {}
 	}
 
 	pool, err := dockertest.NewPool("")
@@ -59,11 +59,11 @@ func prepareOracleTestContainer(t *testing.T) (cleanup func(), connString string
 		t.Fatalf("Could not connect to Oracle docker container: %s", err)
 	}
 
-	return
+	return connString, cleanup
 }
 
 func TestOracle_Initialize(t *testing.T) {
-	cleanup, connURL := prepareOracleTestContainer(t)
+	connURL, cleanup := prepareOracleTestContainer(t)
 	defer cleanup()
 
 	connectionDetails := map[string]interface{}{
@@ -89,7 +89,7 @@ func TestOracle_Initialize(t *testing.T) {
 }
 
 func TestOracle_CreateUser(t *testing.T) {
-	cleanup, connURL := prepareOracleTestContainer(t)
+	connURL, cleanup := prepareOracleTestContainer(t)
 	defer cleanup()
 
 	connectionDetails := map[string]interface{}{
@@ -129,7 +129,7 @@ func TestOracle_CreateUser(t *testing.T) {
 }
 
 func TestOracle_RenewUser(t *testing.T) {
-	cleanup, connURL := prepareOracleTestContainer(t)
+	connURL, cleanup := prepareOracleTestContainer(t)
 	defer cleanup()
 
 	connectionDetails := map[string]interface{}{
@@ -175,7 +175,7 @@ func TestOracle_RenewUser(t *testing.T) {
 }
 
 func TestOracle_RevokeUser(t *testing.T) {
-	cleanup, connURL := prepareOracleTestContainer(t)
+	connURL, cleanup := prepareOracleTestContainer(t)
 	defer cleanup()
 
 	connectionDetails := map[string]interface{}{
@@ -218,7 +218,7 @@ func TestOracle_RevokeUser(t *testing.T) {
 }
 
 func TestOracle_RevokeUserWithCustomStatements(t *testing.T) {
-	cleanup, connURL := prepareOracleTestContainer(t)
+	connURL, cleanup := prepareOracleTestContainer(t)
 	defer cleanup()
 
 	connectionDetails := map[string]interface{}{
@@ -267,7 +267,7 @@ func TestOracle_RotateRootCredentials(t *testing.T) {
 }
 
 func testRotateRootCredentialsCore(t *testing.T, custom bool) {
-	cleanup, connURL := prepareOracleTestContainer(t)
+	connURL, cleanup := prepareOracleTestContainer(t)
 	defer cleanup()
 
 	connectionDetails := map[string]interface{}{

--- a/oracle_test.go
+++ b/oracle_test.go
@@ -490,7 +490,7 @@ func TestSetCredentials_rotationStatements(t *testing.T) {
 			rotationStatements: []string{},
 		},
 		"explicit default": {
-			rotationStatements: []string{`ALTER USER "{{username}}" IDENTIFIED BY "{{password}}"`},
+			rotationStatements: []string{defaultRotateCredsSql},
 		},
 	}
 

--- a/oracle_test.go
+++ b/oracle_test.go
@@ -468,7 +468,7 @@ func TestSetCredentials_missingArguments(t *testing.T) {
 
 			updatedUser, updatedPass, err := db.SetCredentials(ctx, dbplugin.Statements{}, test.userConfig)
 			if err == nil {
-				t.Fatalf("err: %s", err)
+				t.Fatalf("error expected, got nil")
 			}
 			if updatedUser != "" {
 				t.Fatalf("username provided when it should have errored: %s", updatedUser)


### PR DESCRIPTION
- Adds static credential rotation capability.
- Updated container used for tests against an Oracle DB - the previous one had a DMCA takedown and needed to be replaced (see: https://github.com/wnameless/docker-oracle-xe-11g)
- Also updated README with additional details for building, installing, and running the plugin

Related docs update: https://github.com/hashicorp/vault/pull/8168