### PR TITLE
Force dynamic usernames to uppercase

### DIFF
--- a/oracle.go
+++ b/oracle.go
@@ -98,6 +98,7 @@ func (o *Oracle) CreateUser(ctx context.Context, statements dbplugin.Statements,
 	if err != nil {
 		return "", "", err
 	}
+	username = strings.ToUpper(username)
 
 	password, err = o.GeneratePassword()
 	if err != nil {

--- a/oracle_test.go
+++ b/oracle_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -141,6 +142,9 @@ func TestOracle_CreateUser(t *testing.T) {
 			}
 
 			username, password, err := db.CreateUser(context.Background(), statements, usernameConfig, time.Now().Add(time.Minute))
+			if strings.ToUpper(username) != username {
+				t.Fatalf("Username must be uppercase")
+			}
 			switch {
 			case test.expectCreateFail && err == nil:
 				t.Fatalf("error expected, got nil")


### PR DESCRIPTION
Forces dynamic usernames to uppercase since Oracle defaults to uppercase usernames.