### PR TITLE
Adding CircleCI build/test.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,5 +16,7 @@ jobs:
     # save build to CircleCI
     - store_artifacts:
         path: pkg
+    - store_artifacts:
+        path: test-results
     - store_test_results:
         path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2
+jobs:
+  build:
+    machine:
+        docker_layer_caching: true
+    steps:
+    - checkout
+    - run:
+        name: "Build package"
+        command: |
+            make build-in-container
+    - run:
+        name: "Run tests"
+        command: |
+            make test-in-container
+    # save build to CircleCI
+    - store_artifacts:
+        path: pkg
+    - store_test_results:
+        path: test-results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## Unreleased
+
+Features:
+
+Improvements:
+
+Bugs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,20 @@ RUN set -eux; \
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV PKG_CONFIG_PATH $GOPATH/src/github.com/hashicorp/vault-plugin-database-oracle/scripts/linux_amd64
 
 RUN yum install -y \
 		oracle-instantclient19.6-basic \
 		oracle-instantclient19.6-devel
 
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" "$GOPATH/src/github.com/hashicorp/vault-plugin-database-oracle" && chmod -R 777 "$GOPATH"
-WORKDIR $GOPATH/src/github.com/hashicorp/vault-plugin-database-oracle
 
-CMD make bootstrap bin
+WORKDIR $GOPATH/src/github.com/hashicorp/vault-plugin-database-oracle/
+
+COPY . .
+
+RUN mkdir -p test-results/go
+
+RUN make bootstrap
+
+CMD make bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,4 @@ RUN mkdir -p test-results/go
 
 RUN make bootstrap
 
-CMD make bin
+CMD echo "Please specify a command, e.g. 'make bin' or 'make test-ci'"

--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,14 @@ build-cross-image:
 	docker build -t cross-image:latest .
 
 # use the pre-built image (with dependencies set-up) to build the binary
+# by default this will result in the linux_amd64 binary being written to - pkg/bin/linux_amd64/
+# to build the dev binary to bin/ - export VAULT_DEV_BUILD=1
 build-in-container: build-cross-image
 	docker run --rm \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	-v $(CURDIR)/pkg:/go/src/github.com/hashicorp/vault-plugin-database-oracle/pkg \
+	-v $(CURDIR)/bin:/go/src/github.com/hashicorp/vault-plugin-database-oracle/bin \
+	-e VAULT_DEV_BUILD=${VAULT_DEV_BUILD} \
 	cross-image:latest \
 	make bin
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ build-in-container: build-cross-image
 	docker run --rm \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	-v $(CURDIR)/pkg:/go/src/github.com/hashicorp/vault-plugin-database-oracle/pkg \
-	cross-image:latest
+	cross-image:latest \
+	make bin
 
 # run tests in the build container
 test-in-container: build-cross-image
@@ -65,6 +66,7 @@ test-in-container: build-cross-image
 test-ci: fmtcheck generate
 	go get -x github.com/jstemmer/go-junit-report
 	CGO_ENABLED=1 go test $(TEST) -timeout=20m -parallel=4 \
-	-v | go-junit-report > test-results/go/go-test-report.xml
+	-v | tee test-results/go/go-test-report.raw
+	go-junit-report < test-results/go/go-test-report.raw > test-results/go/go-test-report.xml
 
 .PHONY: bin default generate test fmt fmtcheck dev bootstrap

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -47,7 +47,7 @@ PKG_CONFIG_PATH="${DIR}/scripts/${XC_OS}_${XC_ARCH}/"
 echo "==> Building..."
 gox \
     -osarch="${XC_OSARCH}" \
-    -output "pkg/{{.OS}}_{{.Arch}}/vault-plugin-database-oracle" \
+    -output "pkg/bin/{{.OS}}_{{.Arch}}/vault-plugin-database-oracle" \
     ./plugin/.
 
 # Move all the compiled things to the $GOPATH/bin
@@ -57,7 +57,7 @@ IFS=$OLDIFS
 
 # Copy our OS/Arch to the bin/ directory
 if [ "${VAULT_DEV_BUILD}x" != "x" ]; then
-    DEV_PLATFORM="./pkg/$(go env GOOS)_$(go env GOARCH)"
+    DEV_PLATFORM="./pkg/bin/$(go env GOOS)_$(go env GOARCH)"
     for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
         cp ${F} bin/
         cp ${F} ${MAIN_GOPATH}/bin/
@@ -67,7 +67,7 @@ fi
 if [ "${VAULT_DEV_BUILD}x" = "x" ]; then
     # Zip and copy to the dist dir
     echo "==> Packaging..."
-    for PLATFORM in $(find ./pkg -mindepth 1 -maxdepth 1 -type d); do
+    for PLATFORM in $(find ./pkg/bin -mindepth 1 -maxdepth 1 -type d); do
         OSARCH=$(basename ${PLATFORM})
         echo "--> ${OSARCH}"
 


### PR DESCRIPTION
This PR adds a CircleCI build job that will build the linux binary and run all go tests.
This happens on an existing docker build image (cross-image) with all Oracle dependencies installed/configured.
See an example run for this PR below.