### PR TITLE
Use docker mirror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oraclelinux:7
+FROM docker.mirror.hashicorp.services/oraclelinux:7
 
 RUN yum-config-manager --add-repo http://yum.oracle.com/repo/OracleLinux/OL7/oracle/instantclient/x86_64
 


### PR DESCRIPTION
Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. We're updating CircleCI configs, docker compose, dockerfiles, relevant parts of Makefiles, and travis configs. Github actions are excluded, as Github is handling the issue on their end. LMK if you have any q's, otherwise feel free to approve and merge on your own! 