### PR TITLE
Add note about version compatibility with Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ The Vault plugin system is documented on the [Vault documentation site](https://
 You will need to define a plugin directory using the `plugin_directory` configuration directive, then place the
 `vault-plugin-database-oracle` executable generated above in the directory.
 
+**Please note:** Versions v0.3.0 onwards of this plugin are incompatible with Vault versions before 1.6.0 due to an update of the database plugin interface.
+
 Sample commands for registering and starting to use the plugin:
 
 ```


### PR DESCRIPTION
# Overview
Adds a note to explain that versions prior to v0.3.0 must be used for Vault 1.5.x and lower. v0.3.0 doesn't actually exist yet, but I assume we'll be creating that tag soon.

# Related Issues/Pull Requests
Couchbase issue and PR:
[Issue](https://github.com/hashicorp/vault-plugin-database-couchbase/issue/15)
[PR](https://github.com/hashicorp/vault-plugin-database-couchbase/pull/16)
