### PR TITLE
Add ability to fully customize revocation statements

### DIFF
--- a/oracle.go
+++ b/oracle.go
@@ -28,13 +28,13 @@ const (
 
 var (
 	defaultRevocationStatements = []string{
-		`REVOKE CONNECT FROM "{{username}}"`,
-		`REVOKE CREATE SESSION FROM "{{username}}"`,
-		`DROP USER "{{username}}"`,
+		`REVOKE CONNECT FROM {{username}}`,
+		`REVOKE CREATE SESSION FROM {{username}}`,
+		`DROP USER {{username}}`,
 	}
 
 	defaultSessionRevocationStatements = []string{
-		`ALTER USER "{{username}}" ACCOUNT LOCK`,
+		`ALTER USER {{username}} ACCOUNT LOCK`,
 		`begin
 		  for x in ( select sid, serial# from gv$session where username="{{username}}" )
 		  loop
@@ -42,7 +42,7 @@ var (
 		  end loop;
 		  dbms_lock.sleep(1);
 		end;`,
-		`DROP USER "{{username}}"`,
+		`DROP USER {{username}}`,
 	}
 )
 
@@ -326,8 +326,9 @@ func (o *Oracle) secretValues() map[string]string {
 
 // splitQueries conditionally splits the list of commands on semi-colons. If `doNotSplitQueries` is specified, this
 // will return the provided slice of commands without altering them
-func (o *Oracle) splitQueries(rawQueries []string) (queries []string) {
+func (o *Oracle) splitQueries(rawQueries []string) []string {
 	if !o.splitStatements {
+		queries := []string{}
 		for _, rawQ := range rawQueries {
 			newQ := strings.TrimSpace(rawQ)
 			if newQ == "" {
@@ -338,6 +339,7 @@ func (o *Oracle) splitQueries(rawQueries []string) (queries []string) {
 		return queries
 	}
 
+	queries := []string{}
 	for _, rawQ := range rawQueries {
 		split := strutil.ParseArbitraryStringSlice(rawQ, ";")
 		for _, newQ := range split {

--- a/oracle.go
+++ b/oracle.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,15 +21,29 @@ import (
 const (
 	oracleTypeName = "oci8"
 
-	revocationSQL = `
-REVOKE CONNECT FROM {{username}};
-REVOKE CREATE SESSION FROM {{username}};
-DROP USER {{username}};
-`
-
 	defaultRotateCredsSql = `ALTER USER {{username}} IDENTIFIED BY "{{password}}"`
 
 	defaultUsernameTemplate = `{{ printf "V_%s_%s_%s_%s" (.DisplayName | truncate 8) (.RoleName | truncate 8) (random 20) (unix_time) | truncate 30 | uppercase | replace "-" "_" | replace "." "_" }}`
+)
+
+var (
+	defaultRevocationStatements = []string{
+		`REVOKE CONNECT FROM "{{username}}"`,
+		`REVOKE CREATE SESSION FROM "{{username}}"`,
+		`DROP USER "{{username}}"`,
+	}
+
+	defaultSessionRevocationStatements = []string{
+		`ALTER USER "{{username}}" ACCOUNT LOCK`,
+		`begin
+		  for x in ( select sid, serial# from gv$session where username="{{username}}" )
+		  loop
+		   execute immediate ( 'alter system kill session '''|| x.Sid || ',' || x.Serial# || ''' immediate' );
+		  end loop;
+		  dbms_lock.sleep(1);
+		end;`,
+		`DROP USER "{{username}}"`,
+	}
 )
 
 var _ dbplugin.Database = (*Oracle)(nil)
@@ -36,6 +51,9 @@ var _ dbplugin.Database = (*Oracle)(nil)
 type Oracle struct {
 	*connutil.SQLConnectionProducer
 	usernameProducer template.StringTemplate
+
+	splitStatements    bool
+	disconnectSessions bool
 }
 
 func New() (interface{}, error) {
@@ -65,6 +83,18 @@ func (o *Oracle) Initialize(ctx context.Context, req dbplugin.InitializeRequest)
 		usernameTemplate = defaultUsernameTemplate
 	}
 
+	splitStatements, err := coerceToBool(req.Config, "split_statements", true)
+	if err != nil {
+		return dbplugin.InitializeResponse{}, fmt.Errorf("failed to parse 'do_not_split_queries' field: %w", err)
+	}
+	o.splitStatements = splitStatements
+
+	disconnectSessions, err := coerceToBool(req.Config, "disconnect_sessions", true)
+	if err != nil {
+		return dbplugin.InitializeResponse{}, fmt.Errorf("failed to parse 'do_not_disconnect_sessions' field: %w", err)
+	}
+	o.disconnectSessions = disconnectSessions
+
 	up, err := template.NewTemplate(template.Template(usernameTemplate))
 	if err != nil {
 		return dbplugin.InitializeResponse{}, fmt.Errorf("unable to initialize username template: %w", err)
@@ -86,12 +116,23 @@ func (o *Oracle) Initialize(ctx context.Context, req dbplugin.InitializeRequest)
 	return resp, nil
 }
 
-func (o *Oracle) NewUser(ctx context.Context, req dbplugin.NewUserRequest) (dbplugin.NewUserResponse, error) {
-	statements := removeEmpty(req.Statements.Commands)
-	if len(statements) == 0 {
-		return dbplugin.NewUserResponse{}, dbutil.ErrEmptyCreationStatement
+func coerceToBool(m map[string]interface{}, key string, def bool) (bool, error) {
+	rawVal, ok := m[key]
+	if !ok {
+		return def, nil
 	}
 
+	switch val := rawVal.(type) {
+	case bool:
+		return val, nil
+	case string:
+		return strconv.ParseBool(val)
+	}
+
+	return false, fmt.Errorf("invalid type for key [%s]", key)
+}
+
+func (o *Oracle) NewUser(ctx context.Context, req dbplugin.NewUserRequest) (dbplugin.NewUserResponse, error) {
 	o.Lock()
 	defer o.Unlock()
 
@@ -105,7 +146,7 @@ func (o *Oracle) NewUser(ctx context.Context, req dbplugin.NewUserRequest) (dbpl
 		return dbplugin.NewUserResponse{}, fmt.Errorf("failed to get connection: %w", err)
 	}
 
-	err = newUser(ctx, db, username, req.Password, req.Expiration, req.Statements.Commands)
+	err = o.newUser(ctx, db, username, req.Password, req.Expiration, req.Statements.Commands)
 	if err != nil {
 		return dbplugin.NewUserResponse{}, err
 	}
@@ -116,19 +157,7 @@ func (o *Oracle) NewUser(ctx context.Context, req dbplugin.NewUserRequest) (dbpl
 	return resp, nil
 }
 
-func removeEmpty(strs []string) []string {
-	newStrs := []string{}
-	for _, str := range strs {
-		str = strings.TrimSpace(str)
-		if str == "" {
-			continue
-		}
-		newStrs = append(newStrs, str)
-	}
-	return newStrs
-}
-
-func newUser(ctx context.Context, db *sql.DB, username, password string, expiration time.Time, commands []string) error {
+func (o *Oracle) newUser(ctx context.Context, db *sql.DB, username, password string, expiration time.Time, commands []string) error {
 	tx, err := db.Begin()
 	if err != nil {
 		return fmt.Errorf("failed to start a transaction: %w", err)
@@ -136,24 +165,22 @@ func newUser(ctx context.Context, db *sql.DB, username, password string, expirat
 	// Effectively a no-op if the transaction commits successfully
 	defer tx.Rollback()
 
-	for _, stmt := range commands {
-		for _, query := range strutil.ParseArbitraryStringSlice(stmt, ";") {
-			query = strings.TrimSpace(query)
-			if len(query) == 0 {
-				continue
-			}
+	queries := o.splitQueries(commands)
+	if len(queries) == 0 {
+		return dbutil.ErrEmptyCreationStatement
+	}
 
-			m := map[string]string{
-				"username":   username,
-				"name":       username, // backwards compatibility
-				"password":   password,
-				"expiration": expiration.Format("2006-01-02 15:04:05-0700"),
-			}
+	for _, query := range queries {
+		m := map[string]string{
+			"username":   username,
+			"name":       username, // backwards compatibility
+			"password":   password,
+			"expiration": expiration.Format("2006-01-02 15:04:05-0700"),
+		}
 
-			err = dbtxn.ExecuteTxQuery(ctx, tx, m, query)
-			if err != nil {
-				return fmt.Errorf("failed to execute query: %w", err)
-			}
+		err = dbtxn.ExecuteTxQuery(ctx, tx, m, query)
+		if err != nil {
+			return fmt.Errorf("failed to execute query: %w", err)
 		}
 	}
 
@@ -195,7 +222,7 @@ func (o *Oracle) changeUserPassword(ctx context.Context, username string, newPas
 		"password": newPassword,
 	}
 
-	queries := splitQueries(rotateStatements)
+	queries := o.splitQueries(rotateStatements)
 	if len(queries) == 0 { // Extra check to protect against future changes
 		return errors.New("no rotation queries found")
 	}
@@ -215,11 +242,11 @@ func (o *Oracle) changeUserPassword(ctx context.Context, username string, newPas
 	// Effectively a no-op if the transaction commits successfully
 	defer tx.Rollback()
 
-	for _, rawQuery := range queries {
-		parsedQuery := dbutil.QueryHelper(rawQuery, variables)
+	for _, query := range queries {
+		parsedQuery := dbutil.QueryHelper(query, variables)
 		err := dbtxn.ExecuteTxQuery(ctx, tx, nil, parsedQuery)
 		if err != nil {
-			return fmt.Errorf("unable to execute query [%s]: %w", rawQuery, err)
+			return fmt.Errorf("unable to execute query [%s]: %w", query, err)
 		}
 	}
 
@@ -247,36 +274,44 @@ func (o *Oracle) DeleteUser(ctx context.Context, req dbplugin.DeleteUserRequest)
 	// Effectively a no-op if the transaction commits successfully
 	defer tx.Rollback()
 
-	err = o.disconnectSession(db, req.Username)
-	if err != nil {
-		return dbplugin.DeleteUserResponse{}, fmt.Errorf("failed to disconnect user %s: %w", req.Username, err)
+	if o.disconnectSessions {
+		err = o.disconnectSession(db, req.Username)
+		if err != nil {
+			return dbplugin.DeleteUserResponse{}, fmt.Errorf("failed to disconnect user %s: %w", req.Username, err)
+		}
 	}
 
-	revocationStatements := req.Statements.Commands
+	revocationStatements := o.getRevocationStatements(req.Statements.Commands)
 	if len(revocationStatements) == 0 {
-		revocationStatements = []string{revocationSQL}
+		return dbplugin.DeleteUserResponse{}, fmt.Errorf("empty revocation statements")
 	}
 
 	// We can't use a transaction here, because Oracle treats DROP USER as a DDL statement, which commits immediately.
-	for _, stmt := range revocationStatements {
-		for _, query := range strutil.ParseArbitraryStringSlice(stmt, ";") {
-			query = strings.TrimSpace(query)
-			if len(query) == 0 {
-				continue
-			}
+	for _, query := range revocationStatements {
+		m := map[string]string{
+			"username": req.Username,
+			"name":     req.Username, // backwards compatibility
+		}
 
-			m := map[string]string{
-				"username": req.Username,
-				"name":     req.Username, // backwards compatibility
-			}
-
-			if err := dbtxn.ExecuteTxQuery(ctx, tx, m, query); err != nil {
-				return dbplugin.DeleteUserResponse{}, fmt.Errorf("failed to execute query: %w", err)
-			}
+		if err := dbtxn.ExecuteTxQuery(ctx, tx, m, query); err != nil {
+			return dbplugin.DeleteUserResponse{}, fmt.Errorf("failed to execute query: %w", err)
 		}
 	}
 
 	return dbplugin.DeleteUserResponse{}, nil
+}
+
+func (o *Oracle) getRevocationStatements(statements []string) []string {
+	if len(statements) > 0 {
+		statements = o.splitQueries(statements)
+		return statements
+	}
+
+	if !o.splitStatements || !o.disconnectSessions {
+		return defaultSessionRevocationStatements
+	} else {
+		return defaultRevocationStatements
+	}
 }
 
 func (o *Oracle) Type() (string, error) {
@@ -289,7 +324,20 @@ func (o *Oracle) secretValues() map[string]string {
 	}
 }
 
-func splitQueries(rawQueries []string) (queries []string) {
+// splitQueries conditionally splits the list of commands on semi-colons. If `doNotSplitQueries` is specified, this
+// will return the provided slice of commands without altering them
+func (o *Oracle) splitQueries(rawQueries []string) (queries []string) {
+	if !o.splitStatements {
+		for _, rawQ := range rawQueries {
+			newQ := strings.TrimSpace(rawQ)
+			if newQ == "" {
+				continue
+			}
+			queries = append(queries, newQ)
+		}
+		return queries
+	}
+
 	for _, rawQ := range rawQueries {
 		split := strutil.ParseArbitraryStringSlice(rawQ, ";")
 		for _, newQ := range split {

--- a/oracle.go
+++ b/oracle.go
@@ -36,9 +36,9 @@ var (
 	defaultSessionRevocationStatements = []string{
 		`ALTER USER {{username}} ACCOUNT LOCK`,
 		`begin
-		  for x in ( select sid, serial# from gv$session where username="{{username}}" )
+		  for x in ( select inst_id, sid, serial# from gv$session where username="{{username}}" )
 		  loop
-		   execute immediate ( 'alter system kill session '''|| x.Sid || ',' || x.Serial# || ''' immediate' );
+		   execute immediate ( 'alter system kill session '''|| x.Sid || ',' || x.Serial# || '@' || x.inst_id ''' immediate' );
 		  end loop;
 		  dbms_lock.sleep(1);
 		end;`,

--- a/oracle_test.go
+++ b/oracle_test.go
@@ -468,7 +468,7 @@ func TestSplitQueries(t *testing.T) {
 			db := &Oracle{
 				splitStatements: test.splitStatements,
 			}
-			actual := db.splitQueries(test.input)
+			actual := db.parseStatements(test.input)
 
 			if !reflect.DeepEqual(actual, test.expected) {
 				t.Fatalf("Actual: %s\nExpected: %s", actual, test.expected)

--- a/oracle_test.go
+++ b/oracle_test.go
@@ -361,7 +361,7 @@ func TestOracle_RevokeUser(t *testing.T) {
 	}
 }
 
-func TestSplitQueries(t *testing.T) {
+func TestParseStatements(t *testing.T) {
 	type testCase struct {
 		splitStatements bool
 
@@ -373,27 +373,27 @@ func TestSplitQueries(t *testing.T) {
 		"nil input": {
 			splitStatements: true,
 			input:           nil,
-			expected:        nil,
+			expected:        []string{},
 		},
 		"empty input": {
 			splitStatements: true,
 			input:           []string{},
-			expected:        nil,
+			expected:        []string{},
 		},
 		"empty string": {
 			splitStatements: true,
 			input:           []string{""},
-			expected:        nil,
+			expected:        []string{},
 		},
 		"string with only semicolon": {
 			splitStatements: true,
 			input:           []string{";"},
-			expected:        nil,
+			expected:        []string{},
 		},
 		"only semicolons": {
 			splitStatements: true,
 			input:           []string{";;;;"},
-			expected:        nil,
+			expected:        []string{},
 		},
 		"single input": {
 			splitStatements: true,


### PR DESCRIPTION
# Overview
- Adds the ability to override the default revocation behavior so users with differing environments can revoke open sessions during lease revocation. This should work with AWS RDS and other systems too.
- Also includes a couple of feature flags: `split_statements` and `disconnect_sessions`

# Design of Change
- `split_statements` (default: `true`) - Indicates the statements specified should be split on semi-colons. This is the current behavior. When true, this allows using a single string to specify multiple SQL statements.
  - Example: `'CREATE USER "{{username}}"; GRANT CONNECT TO "{{username}}"` This is interpreted as two separate statements: `CREATE USER ...` and `GRANT CONNECT ...`
  - If set to `false` this will not attempt to split the statements. This allows for more complex queries such as stored or inline procedures.
- `disconnect_sessions` (default: `true`) - Indicates the plugin should disconnect any open sessions prior to running the revocation statements. If set to `false`, the revocation statements should include session disconnect logic.
- If no custom revocation statements are specified, it will use default revocation statements depending on the state of the two feature flags:
  - If `split_statements` and `disconnect_sessions` are both set to false, it will use revocation statements with disconnect logic built in (see below)
  - If either `split_statements` or `disconnect_sessions` are set to true (or not specified), it will use the current default revocation statements (see below)

<details>
<summary>Default revocation statements with session disconnection logic</summary>

```sql
ALTER USER '{{username}}' ACCOUNT LOCK

begin
	for x in ( select sid, serial# from gv$session where username='{{username}}' )
	loop
		execute immediate ( 'alter system kill session '''|| x.Sid || ',' || x.Serial# || ''' immediate' );
	end loop;
	dbms_lock.sleep(1);
end;

DROP USER {{username}}
```
</details>

<details>
<summary>Default revocation statements without session disconnection logic</summary>

```sql
REVOKE CONNECT FROM '{{username}}'
REVOKE CREATE SESSION FROM '{{username}}'
DROP USER '{{username}}'
```
</details>

# Related Issues/Pull Requests
Replaces: https://github.com/hashicorp/vault-plugin-database-oracle/pull/31 - Kill sessions in a RAC aware manner
Partially fixes: https://github.com/hashicorp/vault-plugin-database-oracle/issues/52 - Disconnect query is hardcoded - doesn't allow fully customizable revocation_statement

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
  - TBD
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
  - All tests are run in CI, so no extra ones here
- [x] Backwards compatible
