### PR TITLE
Vault oracle plugin readme - fix syntax of plugin_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ $ vault write sys/plugins/catalog/database/vault-plugin-database-oracle \
 
 $ vault secrets enable database
 
-$ vault write database/config/oracle plugin_name \
-    vault-plugin-database-oracle \
+$ vault write database/config/oracle \
+    plugin_name=vault-plugin-database-oracle \
     allowed_roles="*" \
     connection_url='{{username}}/{{password}}@//url.to.oracle.db:1521/oracle_service' \
     username='vaultadmin' \


### PR DESCRIPTION
example syntax incorrect, changing per https://www.vaultproject.io/docs/secrets/databases/oracle#connect-using-ssl

# Overview
Syntax fix in readme only

# Design of Change
NA

# Related Issues/Pull Requests
NA

# Contributor Checklist
[na ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[na ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ yes] Backwards compatible
