### PR TITLE
Add multiplexing support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,9 @@ go 1.12
 require (
 	github.com/containerd/continuity v0.0.0-20200709052629-daa8e1ccc0bc // indirect
 	github.com/go-kit/kit v0.10.0 // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/hashicorp/vault/api v1.3.0
-	github.com/hashicorp/vault/sdk v0.3.0
+	github.com/hashicorp/vault/sdk v0.3.1-0.20220217145033-3565c90cf8ed
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lib/pq v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,10 @@ go 1.12
 require (
 	github.com/containerd/continuity v0.0.0-20200709052629-daa8e1ccc0bc // indirect
 	github.com/go-kit/kit v0.10.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/hashicorp/vault/api v1.3.0
-	github.com/hashicorp/vault/sdk v0.3.1-0.20220217145033-3565c90cf8ed
+	github.com/hashicorp/vault/sdk v0.4.0
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lib/pq v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -301,8 +301,9 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/vault/api v1.3.0 h1:uDy39PLSvy6gtKyjOCRPizy2QdFiIYSWBR2pxCEzYL8=
 github.com/hashicorp/vault/api v1.3.0/go.mod h1:EabNQLI0VWbWoGlA+oBLC8PXmR9D60aUVgQGvangFWQ=
-github.com/hashicorp/vault/sdk v0.3.0 h1:kR3dpxNkhh/wr6ycaJYqp6AFT/i2xaftbfnwZduTKEY=
 github.com/hashicorp/vault/sdk v0.3.0/go.mod h1:aZ3fNuL5VNydQk8GcLJ2TV8YCRVvyaakYkhZRoVuhj0=
+github.com/hashicorp/vault/sdk v0.3.1-0.20220217145033-3565c90cf8ed h1:HE3TvMKNm622sDdruZV2G5LZtTmiVjnY82QSO0a5YuQ=
+github.com/hashicorp/vault/sdk v0.3.1-0.20220217145033-3565c90cf8ed/go.mod h1:LzlzYEnxJWaC5mlt2nOVJimp5R15ecXAucsdjRc7KC0=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
@@ -330,6 +331,7 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/kardianos/osext v0.0.0-20151222153229-29ae4ffbc9a6/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
+github.com/keybase/go-crypto v0.0.0-20190403132359-d65b6b94177f/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v0.0.0-20161130080628-0de1eaf82fa3/go.mod h1:jxZFDH7ILpTPQTk+E2s+z4CUas9lVNjIuKR4c5/zKgM=

--- a/go.sum
+++ b/go.sum
@@ -302,8 +302,8 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/hashicorp/vault/api v1.3.0 h1:uDy39PLSvy6gtKyjOCRPizy2QdFiIYSWBR2pxCEzYL8=
 github.com/hashicorp/vault/api v1.3.0/go.mod h1:EabNQLI0VWbWoGlA+oBLC8PXmR9D60aUVgQGvangFWQ=
 github.com/hashicorp/vault/sdk v0.3.0/go.mod h1:aZ3fNuL5VNydQk8GcLJ2TV8YCRVvyaakYkhZRoVuhj0=
-github.com/hashicorp/vault/sdk v0.3.1-0.20220217145033-3565c90cf8ed h1:HE3TvMKNm622sDdruZV2G5LZtTmiVjnY82QSO0a5YuQ=
-github.com/hashicorp/vault/sdk v0.3.1-0.20220217145033-3565c90cf8ed/go.mod h1:LzlzYEnxJWaC5mlt2nOVJimp5R15ecXAucsdjRc7KC0=
+github.com/hashicorp/vault/sdk v0.4.0 h1:r60AsH84FZOPKJWP0OyS/chxcD98lKa/FN0VSJhSLWc=
+github.com/hashicorp/vault/sdk v0.4.0/go.mod h1:aZ3fNuL5VNydQk8GcLJ2TV8YCRVvyaakYkhZRoVuhj0=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
@@ -331,7 +331,6 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/kardianos/osext v0.0.0-20151222153229-29ae4ffbc9a6/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
-github.com/keybase/go-crypto v0.0.0-20190403132359-d65b6b94177f/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v0.0.0-20161130080628-0de1eaf82fa3/go.mod h1:jxZFDH7ILpTPQTk+E2s+z4CUas9lVNjIuKR4c5/zKgM=

--- a/oracle.go
+++ b/oracle.go
@@ -56,7 +56,14 @@ type Oracle struct {
 	disconnectSessions bool
 }
 
-func New() (dbplugin.Database, error) {
+func NewWithMultiplex() (dbplugin.Database, error) {
+	db := new()
+	// Wrap the plugin with middleware to sanitize errors
+	dbType := dbplugin.NewDatabaseErrorSanitizerMiddleware(db, db.secretValues)
+	return dbType, nil
+}
+
+func New() (interface{}, error) {
 	db := new()
 	// Wrap the plugin with middleware to sanitize errors
 	dbType := dbplugin.NewDatabaseErrorSanitizerMiddleware(db, db.secretValues)

--- a/oracle.go
+++ b/oracle.go
@@ -56,7 +56,7 @@ type Oracle struct {
 	disconnectSessions bool
 }
 
-func New() (interface{}, error) {
+func New() (dbplugin.Database, error) {
 	db := new()
 	// Wrap the plugin with middleware to sanitize errors
 	dbType := dbplugin.NewDatabaseErrorSanitizerMiddleware(db, db.secretValues)

--- a/oracle.go
+++ b/oracle.go
@@ -56,13 +56,6 @@ type Oracle struct {
 	disconnectSessions bool
 }
 
-func NewWithMultiplex() (dbplugin.Database, error) {
-	db := new()
-	// Wrap the plugin with middleware to sanitize errors
-	dbType := dbplugin.NewDatabaseErrorSanitizerMiddleware(db, db.secretValues)
-	return dbType, nil
-}
-
 func New() (interface{}, error) {
 	db := new()
 	// Wrap the plugin with middleware to sanitize errors

--- a/plugin/main.go
+++ b/plugin/main.go
@@ -23,7 +23,7 @@ func main() {
 
 // Run instantiates an Oracle object, and runs the RPC server for the plugin
 func Run() error {
-	dbplugin.ServeMultiplex(plugin.New)
+	dbplugin.ServeMultiplex(plugin.NewWithMultiplex)
 
 	return nil
 }

--- a/plugin/main.go
+++ b/plugin/main.go
@@ -23,12 +23,7 @@ func main() {
 
 // Run instantiates an Oracle object, and runs the RPC server for the plugin
 func Run() error {
-	db, err := plugin.New()
-	if err != nil {
-		return err
-	}
-
-	dbplugin.Serve(db.(dbplugin.Database))
+	dbplugin.ServeMultiplex(plugin.New)
 
 	return nil
 }

--- a/plugin/main.go
+++ b/plugin/main.go
@@ -23,7 +23,7 @@ func main() {
 
 // Run instantiates an Oracle object, and runs the RPC server for the plugin
 func Run() error {
-	dbplugin.ServeMultiplex(plugin.NewWithMultiplex)
+	dbplugin.ServeMultiplex(plugin.New)
 
 	return nil
 }


### PR DESCRIPTION
# Description

Add multiplexing support to the Oracle db plugin.

This is pointing to a pseudo tag on the vault repo. Steps taken to update go.mod:
- `go get github.com/hashicorp/vault/sdk@sdk/v0.4.0`
- `go mod tidy`

### Test
To test this out take the following steps:
- run oracle DB
- checkout this branch
- build oracle plugin
- build vault with vault main branch
- run vault