### PR TITLE
Add config key to the promote-staging event

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -105,6 +105,7 @@ event "promote-staging" {
     organization = "hashicorp"
     repository = "crt-workflows-common"
     workflow = "promote-staging"
+    config = "release-metadata.hcl"
   }
 
   notification {


### PR DESCRIPTION
# Overview
We need to pass the `release-metadata.hcl` filename to the promote-staging event -- this is needed prior to the RelAPI launch.

# Contributor Checklist
These are CI-only changes that do not affect the plugin.
