### PR TITLE
[CI-only] Use pattern matching for release_branches

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -10,10 +10,7 @@ project "vault-plugin-database-oracle" {
     repository = "vault-plugin-database-oracle"
     release_branches = [
         "main",
-        "release/vault-1.9.x",
-        "release/vault-1.10.x",
-        "release/vault-1.11.x",
-        "release/vault-1.12.x",
+        "release/**",
     ]
   }
 }


### PR DESCRIPTION
### Description
Pattern matching was [recently added](https://github.com/hashicorp/crt-orchestrator/pull/51) so that teams no longer have to explicitly list every branch that should trigger the CRT pipeline. This simplifies release preparation- anytime a new release branch is created, it will produce releasable artifacts and exercise the pipeline.

### Testing & Reproduction steps
This has been tested in multiple projects since being rolled out. There are no project specific tests that need to be done here.

### Links
PR where this functionality was added: https://github.com/hashicorp/crt-orchestrator/pull/51

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [X] not a security concern