### PR TITLE
Readme update - Plugin register operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ Sample commands for plugin registration in current versions of Vault and startin
 
 ```shell-session
 $ vault plugin register -sha256=<SHA256 Hex value of the plugin binary> \
-    secret \                  # type
+    database \                  # type
     vault-plugin-database-oracle
-Success! Registered plugin: myplugin-database-plugin
+Success! Registered plugin: vault-plugin-database-oracle
 ```
 
 Vault versions prior to v0.10.4 lacked the `vault plugin` operator and the 

--- a/README.md
+++ b/README.md
@@ -100,15 +100,27 @@ You will need to define a plugin directory using the `plugin_directory` configur
 
 **Please note:** Versions v0.3.0 onwards of this plugin are incompatible with Vault versions before 1.6.0 due to an update of the database plugin interface.
 
-Sample commands for registering and starting to use the plugin:
+Sample commands for plugin registration in current versions of Vault and starting to use the plugin:
 
+```shell-session
+$ vault plugin register -sha256=<SHA256 Hex value of the plugin binary> \
+    secret \                  # type
+    vault-plugin-database-oracle
+Success! Registered plugin: myplugin-database-plugin
 ```
+
+Vault versions prior to v0.10.4 lacked the `vault plugin` operator and the 
+registration step for them is:
+
+```shell-session
 $ shasum -a 256 vault-plugin-database-oracle > /tmp/oracle-plugin.sha256
 
 $ vault write sys/plugins/catalog/database/vault-plugin-database-oracle \
     sha256=$(cat /tmp/oracle-plugin.sha256) \
     command="vault-plugin-database-oracle"
+```
 
+```shell-session
 $ vault secrets enable database
 
 $ vault write database/config/oracle \


### PR DESCRIPTION
Updated the Readme to the current registration method and keeping the old registration method for older versions.

# Overview
The change is need in order to be consistent with the current registration method for plugins but also for preserving the registration method for versions earlier than 0.10.4.
The change includes the example of registration using the `vault plugin register ` command.
The change will make complete the example for old and new methods.

# Design of Change

# Related Issues/Pull Requests

# Contributor Checklist

