### PR TITLE
Update to Go 1.20.2 and prep CHANGELOG for release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN yum update -y && yum install -y  \
 		zip \
 		git
 
-ENV GOLANG_VERSION 1.19.5
+ENV GOLANG_VERSION 1.20.2
 
 RUN set -eux; \
 	url="https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz"; \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/vault-plugin-database-oracle
 
-go 1.19
+go 1.20
 
 require (
 	github.com/hashicorp/vault/api v1.9.0


### PR DESCRIPTION
No other updates seemed to be necessary.