### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For linux/amd64, pre-built binaries can be found at
 See the following table to determine what version of the Oracle Instant Client
 SDK the plugin was built with:
 
-|Plugin Release|Instance Client Version|
+|Plugin Release|Instant Client Version|
 |---|---|
 |v0.8.1|19.18|
 |v0.8.0|19.18|


### PR DESCRIPTION
Changes "Instance Client Version" to "Instant Client Version" in the releases table.

# Overview

This just fixes a typo in the README. It's minor, but it confused me for longer than I'd like to admit.

I did search for other occurrences of this misspelling. This is the only one.

# Design of Change

Documentation only

# Related Issues/Pull Requests

None

# Contributor Checklist

N/A