### PR TITLE
fix: errcheck for parsing CLI flags

### DIFF
--- a/plugin/main.go
+++ b/plugin/main.go
@@ -15,12 +15,14 @@ import (
 func main() {
 	apiClientMeta := &api.PluginAPIClientMeta{}
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args[1:])
+
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		fatal(err)
+	}
 
 	err := Run()
 	if err != nil {
-		log.Println(err)
-		os.Exit(1)
+		fatal(err)
 	}
 }
 
@@ -29,4 +31,9 @@ func Run() error {
 	dbplugin.ServeMultiplex(plugin.New)
 
 	return nil
+}
+
+func fatal(err error) {
+	log.Println(err)
+	os.Exit(1)
 }


### PR DESCRIPTION
# Overview

Add missing error check to `main()` for parsing CLI flags.

# Design of Change

Error check was missing.

# Related Issues/Pull Requests

None

# Contributor Checklist

Fixed in various Vault plugin repositories before such as https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/202 and https://github.com/hashicorp/vault/pull/28692