### PR TITLE
Bump go version dockerfile and go mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN yum update -y && yum install -y  \
 		zip \
 		git
 
-ENV GOLANG_VERSION 1.23.3
+ENV GOLANG_VERSION 1.23.6
 
 RUN set -eux; \
 	url="https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz"; \

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/hashicorp/vault-plugin-database-oracle
 
-go 1.23.3
-
-toolchain go1.23.4
+go 1.23.6
 
 require (
 	github.com/hashicorp/vault/api v1.15.0


### PR DESCRIPTION
# Overview
Followup to https://github.com/hashicorp/vault-plugin-database-oracle/pull/173#issuecomment-2675346581. 

We will definitely still use the Dockerfile for dev builds, TBD for the external build and release process depending on vault-plugin-release changes in [VAULT-33789](https://hashicorp.atlassian.net/browse/VAULT-33789)

# Design of Change
How was this change implemented?

# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible


[VAULT-33789]: https://hashicorp.atlassian.net/browse/VAULT-33789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ