### PR TITLE
add output dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ _test
 
 /pkg/
 /bin/
+/output/
 
 # Architecture specific extensions/prefixes
 *.[568vq]


### PR DESCRIPTION
# Overview

For [VAULT-31437](https://hashicorp.atlassian.net/browse/VAULT-31437), we will be using [`vault-plugin-release`](https://github.com/hashicorp/vault-plugin-release) to release new versions of the Oracle plugin going forward (see WIP branches [vault-33789-support-enterprise-plugin-releases-oracle](https://github.com/hashicorp/vault-plugin-release/compare/vault-33789-support-enterprise-plugin-releases-oracle?expand=1&w=1#diff-e922bbc1d7052299f20e8042441f54fc1c826646a15fb48cac0faa34f9c99c58) and [vault-33789-refactor-build-oracle-with-docker](https://github.com/hashicorp/vault-plugin-release/compare/vault-33789-support-enterprise-plugin-releases-oracle...vault-33789-refactor-build-oracle-with-docker?expand=1#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR252)). 

As part of these changes, the `release.yaml` workflow in `vault-plugin-release` will call `make build-in-container`, then copy the resulting `pkg/bin/linux_amd64/vault-plugin-database-oracle` (owned by the root user with `-rwxr-xr-x` permissions) to the `output` directory so it can be used by goreleaser in subsequent steps. This is necessary so the copy is owned by the `runner` user with sufficient permissions during the goreleaser steps. I've named it `output` following the example at https://goreleaser.com/customization/prebuilt/ to use a prebuilt binary in goreleaser.

We need to ignore everything in the `/output/` directory to avoid `git is in a dirty state` errors from goreleaser described at https://goreleaser.com/errors/dirty/.

Note: After we merge this to `vault-plugin-database-oracle`, we should fetch it and merge into `vault-plugin-database-oracle-enterprise` before releasing `vault-plugin-database-oracle-enterprise`.

# Related Issues/Pull Requests
[VAULT-31437](https://hashicorp.atlassian.net/browse/VAULT-31437)
[vault-plugin-release/vault-33789-support-enterprise-plugin-releases-oracle](https://github.com/hashicorp/vault-plugin-release/compare/vault-33789-support-enterprise-plugin-releases-oracle?expand=1&w=1#diff-e922bbc1d7052299f20e8042441f54fc1c826646a15fb48cac0faa34f9c99c58)
[vault-plugin-release/vault-33789-refactor-build-oracle-with-docker](https://github.com/hashicorp/vault-plugin-release/compare/vault-33789-support-enterprise-plugin-releases-oracle...vault-33789-refactor-build-oracle-with-docker?expand=1#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR252)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible


[VAULT-31437]: https://hashicorp.atlassian.net/browse/VAULT-31437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VAULT-31437]: https://hashicorp.atlassian.net/browse/VAULT-31437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ