### PR TITLE
bump oracle instant client from 19.23 to 19.26

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,11 +20,11 @@ jobs:
       - name: Check OSV
         id: osv-check
         run: |
-          test $(curl -XPOST https://api.osv.dev/v1/query -d '{"package":{"name":"oracle-instantclient19.23-basic"}, "version": "19.23"}') = "{}"
+          test $(curl -XPOST https://api.osv.dev/v1/query -d '{"package":{"name":"oracle-instantclient19.26-basic"}, "version": "19.26"}') = "{}"
       - name: Check NIST NVD
         id: nvd-check
         run: |
-          test $(curl -sSL 'https://services.nvd.nist.gov/rest/json/cves/2.0?cpeName=cpe:2.3:a:oracle:instant_client:19.23:*' | jq .totalResults) -eq 0
+          test $(curl -sSL 'https://services.nvd.nist.gov/rest/json/cves/2.0?cpeName=cpe:2.3:a:oracle:instant_client:19.26:*' | jq .totalResults) -eq 0
 
   get-product-version:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## Unreleased
 
+IMPROVEMENTS:
 * bump go version to 1.23.6
-* Updated indirect dependencies [GH-179](https://github.com/hashicorp/vault-plugin-database-oracle/pull/179)
+* Update indirect dependencies [GH-179](https://github.com/hashicorp/vault-plugin-database-oracle/pull/179)
   * golang.org/x/crypto v0.31.0 -> golang.org/x/crypto v0.35.0
   * golang.org/x/oauth2 v0.24.0 -> golang.org/x/oauth2 v0.27.0
   * github.com/go-jose/go-jose/v4 v4.0.4 -> github.com/go-jose/go-jose/v4 v4.0.5
+* bump Oracle Instant Client from 19.23 to 19.26
 
 ## 0.10.2 (January 9, 2024)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 ENV PKG_CONFIG_PATH $GOPATH/src/github.com/hashicorp/vault-plugin-database-oracle/scripts/linux_amd64
 
 RUN yum install -y \
-		oracle-instantclient19.23-basic \
-		oracle-instantclient19.23-devel
+		oracle-instantclient19.26-basic \
+		oracle-instantclient19.26-devel
 
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" "$GOPATH/src/github.com/hashicorp/vault-plugin-database-oracle" && chmod -R 777 "$GOPATH"
 

--- a/scripts/linux_amd64/oci8.pc
+++ b/scripts/linux_amd64/oci8.pc
@@ -1,8 +1,8 @@
-libdir=/usr/lib/oracle/19.23/client64/lib
-includedir=/usr/include/oracle/19.23/client64
+libdir=/usr/lib/oracle/19.26/client64/lib
+includedir=/usr/include/oracle/19.26/client64
 
 Name: oci8
 Description: oci8 library
 Libs: -L${libdir} -lclntsh
 Cflags: -I${includedir}
-Version: 19.23
+Version: 19.26


### PR DESCRIPTION
# Overview
Preparing for the 0.11.0+ent release by bumping the Oracle Instant Client from 19.23 to 19.26. This will be merged into the ENT repo before we release.

# Related Issues/Pull Requests
[VAULT-31437](https://hashicorp.atlassian.net/browse/VAULT-31437)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
